### PR TITLE
Refactor imports and improve NotRequired handling

### DIFF
--- a/nodes/utils.py
+++ b/nodes/utils.py
@@ -3,7 +3,17 @@ import os
 import mimetypes
 import json
 import subprocess
-from typing import NotRequired, TypedDict, Any
+from typing import TypedDict, Any
+
+try:
+    from typing import NotRequired
+except ImportError:
+    try:
+        from typing_extensions import NotRequired
+    except ImportError:
+        def NotRequired(x):
+            return x
+
 from pathlib import Path
 
 import torchaudio


### PR DESCRIPTION
Most pods will have 3.10 by default, not 3.11, and it causes importing issues

Not adding it as a dependency in requirements.txt because it might be too overkill for this in particular, but it tries `typing_extensions` anyways just in case another node installed it