### PR TITLE
allow to send video+audio

### DIFF
--- a/nodes/telegram.py
+++ b/nodes/telegram.py
@@ -304,7 +304,7 @@ class SendVideo(SendGeneric):
     def send_video(self, bot: TelegramBot, video, send_as, trigger=None, **params):
         params = utils.cleanup_params(params)
         
-        file_path = [v for v in video[1] if not v.endswith(".png")][0]
+        file_path = [v for v in video[1] if not v.endswith(".png")][-1]
 
         file_name = file_path.rsplit("/", 1)[-1]
         mimetype = mimetypes.guess_type(file_name)[0] or "application/octet_stream"


### PR DESCRIPTION
I've encountered an issue in the original branch when using the 'Send Video' node with videos that contain audio. This happens in particular when the configuration is set not to save intermediate files.

I found the error in the ```telegram.py``` file, on line 319, with the following error message: ```FileNotFoundError: [Errno 2] No such file or directory: [...]```

Looking through the function, I found that `file_path` was restricted to the first match that didn’t end in ‘.png’; since the output of 'Video Combine VHS' when the audio is present is as follows:
```
[
    <boolean>,
    [
        "filepath of .png file",
        "filepath of .mp4 file without audio",
        "filepath of .mp4 file with audio"
    ]
]
```
 by changing this to `[-1]`, I’ve solved the problem for myself.

I propose changing line 307 of ```telegram.py``` from:
```file_path = [v for v in video[1] if not v.endswith(‘.png’)][0]```
to:
```file_path = [v for v in video[1] if not v.endswith(‘.png’)][-1]``` for a permanent solution